### PR TITLE
CU-9wuttg Make child divs below first level not use top margin

### DIFF
--- a/source/sass/object/_article.scss
+++ b/source/sass/object/_article.scss
@@ -3,10 +3,10 @@ $article-content-headings:
 '.h1', '.h2', '.h3', '.h4', '.h5', '.h6' !default;
 
 $article-content-elements:
-'p', 'ul', 'ol', 'blockquote', 'img', 'figure', 'table', 'div' !default;
+'p', 'ul', 'ol', 'blockquote', 'img', 'figure', 'table', '> div' !default;
 
 .c-article {
-    #{$article-content-elements} {
+    > #{$article-content-elements} {
         margin-top: $base * 2;
     }
 

--- a/source/sass/object/_article.scss
+++ b/source/sass/object/_article.scss
@@ -6,7 +6,7 @@ $article-content-elements:
 'p', 'ul', 'ol', 'blockquote', 'img', 'figure', 'table', '> div' !default;
 
 .c-article {
-    > #{$article-content-elements} {
+    #{$article-content-elements} {
         margin-top: $base * 2;
     }
 


### PR DESCRIPTION
Fix problems related to collection items getting margin from article css.
![Screenshot 2020-11-11 at 10 07 59](https://user-images.githubusercontent.com/154269/98799778-d7e2b380-240f-11eb-81f6-2cd6195e1a68.png)
