### PR TITLE
Fix pageinate pages returning max pages

### DIFF
--- a/source/js/pagination.js
+++ b/source/js/pagination.js
@@ -42,11 +42,13 @@ export default class Pagination {
     }
 
     paginatePages() {
-        if(this.maxPages) {
-            return parseInt(this.maxPages);
+        const numberOfPages = Math.ceil(this.list.length / this.perPage);
+
+        if(this.maxPages && (numberOfPages > this.maxPages)) {
+            return this.maxPages;
         }
 
-        return Math.ceil(this.list.length / this.perPage);
+        return numberOfPages;
     }
 
     paginationLinks() {


### PR DESCRIPTION
Fix paginatePages method to not return max pages if that number is
higher than the actual number of items in the list divided by perPage.

Test by
 - Setting perPage
 - Setting maxPages