### PR TITLE
CU-1kxu0f1 remove 100% width on images

### DIFF
--- a/source/sass/component/_image.scss
+++ b/source/sass/component/_image.scss
@@ -81,7 +81,6 @@ $radius: (
 
     .c-image__image {
         border-radius: $border-radius-xs;
-        width: 100%;
         max-width: 100%;
         display: block;
     }


### PR DESCRIPTION
Tested on https://modul-test.helsingborg.io/bild-image/ in browser and locally.
Looks correct without.