### PR TITLE
remove card footer border

### DIFF
--- a/source/sass/component/_card.scss
+++ b/source/sass/component/_card.scss
@@ -51,7 +51,6 @@ $c-card-border-color-divider: var(--c-card-border-color-divider, $color-border-d
 
     &--highlight {
         .c-card__header,
-        .c-card__footer,
         .c-card__body {
             border-left: $base solid $color-primary;
         }


### PR DESCRIPTION
Removes the card footer border styling since it is moved inside of the card body