### PR TITLE
Fixing card borders

### DIFF
--- a/source/sass/component/_card.scss
+++ b/source/sass/component/_card.scss
@@ -37,14 +37,15 @@ $c-card-border-color-divider: var(--c-card-border-color-divider, $color-border-d
         border-bottom-right-radius: $c-card-border-radius;
     }
 
-        &--size-sm.c-card--size-xs {
+    &--size-sm.c-card--size-xs {
         & > *:first-child {
             .c-card__image-background {
                 border-top-right-radius: 0;
             }
         }
+        
         & .c-card__image + .c-card__body {
-             border-bottom-left-radius: 0;
+            border-bottom-left-radius: 0;
         }
     }
 
@@ -161,8 +162,7 @@ $c-card-border-color-divider: var(--c-card-border-color-divider, $color-border-d
 
     &--size-sm .c-card__image, &--size-sm .c-card__image-background {
         flex-basis: 250px;
-          border-radius: $c-card-border-radius 0 0 $c-card-border-radius;
-          border-top-right-radius: 0;
+        border-radius: $c-card-border-radius 0 0 $c-card-border-radius;
     }
 
     &--size-sm .c-card__image + .c-card__body {

--- a/source/sass/component/_card.scss
+++ b/source/sass/component/_card.scss
@@ -30,13 +30,29 @@ $c-card-border-color-divider: var(--c-card-border-color-divider, $color-border-d
             border-top-left-radius: $c-card-border-radius;
             border-top-right-radius: $c-card-border-radius;
         }
-    }
+    } 
 
     & > *:last-child  {
         border-bottom-left-radius: $c-card-border-radius;
         border-bottom-right-radius: $c-card-border-radius;
     }
 
+        &--size-sm.c-card--size-xs {
+        & > *:first-child {
+            .c-card__image-background {
+                border-top-right-radius: 0;
+            }
+        }
+        & .c-card__image + .c-card__body {
+             border-bottom-left-radius: 0;
+        }
+    }
+
+    & figure.c-image {
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
+    }
+ 
     &__header i{
         vertical-align: top;
 
@@ -143,8 +159,10 @@ $c-card-border-color-divider: var(--c-card-border-color-divider, $color-border-d
 
     }
 
-    &--size-sm .c-card__image {
+    &--size-sm .c-card__image, &--size-sm .c-card__image-background {
         flex-basis: 250px;
+          border-radius: $c-card-border-radius 0 0 $c-card-border-radius;
+          border-top-right-radius: 0;
     }
 
     &--size-sm .c-card__image + .c-card__body {


### PR DESCRIPTION
Noticed an issue with the borders radius when cards contained both the --size-sm and --size-xs class. The borders were not showing or showing in wrong corners. See example below:

![image](https://user-images.githubusercontent.com/103985736/182339415-e8a54261-a55b-4350-a5d0-06902516fc75.png)

With updated css it will look like expected:
![image](https://user-images.githubusercontent.com/103985736/182340010-c3c0a7e8-5950-4b1c-8a2a-1a0601a5691b.png)

Responsivity works fine and I cant seem to find any element that gets impacted negatively by the changes
