### PR TITLE
Fix up Lorem Picsum URLs

### DIFF
--- a/views/pages/components/molecules/avatar.blade.php
+++ b/views/pages/components/molecules/avatar.blade.php
@@ -25,7 +25,7 @@
 
             <div class="grid-md-3">
                 @avatar([
-                    'image' => "https://picsum.photos/70/70?image=64",
+                    'image' => "https://picsum.photos/id/64/70/70",
                     'name' => "Cookie Monster"
                 ])
                 @endavatar

--- a/views/pages/components/organisms/segment.blade.php
+++ b/views/pages/components/organisms/segment.blade.php
@@ -161,7 +161,7 @@
             <div class="grid-s-12 grid-sm-6 grid-md-6">
                 @card([
                     'href' => 'http://styleguide.helsingborg.se/card',
-                    'image' => 'https://picsum.photos/300/200?image=1016',
+                    'image' => 'https://picsum.photos/id/1016/300/200',
                     'title' => ['text' => 'Melon sierra leone bologi rutabaga', 'position' => 'top'],
                     'byline' => ['text' => 'Celery quandong swiss chard chicory', 'position' => 'top'],
                     'classList' => ['c-card--shadow-on-hover'],
@@ -177,7 +177,7 @@
             <div class="grid-s-12 grid-sm-6 grid-md-6">
                 @card([
                     'href' => 'http://styleguide.helsingborg.se/card',
-                    'image' => 'https://picsum.photos/300/200?image=1071',
+                    'image' => 'https://picsum.photos/id/1071/300/200',
                     'title' => ['text' => 'Cheddar ricotta croque monsieur', 'position' => 'body'],
                     'classList' => ['c-card--shadow-on-hover'],
                     'byline' => ['text' => 'Melted cheese camembert de normandie cheese triangles', 'position' => 'body'],

--- a/views/pages/components/usage/avatar/image.blade.php
+++ b/views/pages/components/usage/avatar/image.blade.php
@@ -1,6 +1,6 @@
 @avatar(
     [
-        'image' => "https://picsum.photos/70/70?image=64",
+        'image' => "https://picsum.photos/id/64/70/70",
         'name' => "Cookie Monster"
     ]
 )

--- a/views/pages/components/usage/block/gutter.blade.php
+++ b/views/pages/components/usage/block/gutter.blade.php
@@ -5,7 +5,7 @@
             'meta' => 'Parturient Ultricies',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=88',
+                'src' => 'https://picsum.photos/id/88/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ],
@@ -19,7 +19,7 @@
             'meta' => 'Nibh Sit',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=87',
+                'src' => 'https://picsum.photos/id/87/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -32,7 +32,7 @@
             'meta' => 'Commodo Fringilla',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=32',
+                'src' => 'https://picsum.photos/id/32/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -45,7 +45,7 @@
             'meta' => 'Ullamcorper Euismod Pharetra',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=33',
+                'src' => 'https://picsum.photos/id/33/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -58,7 +58,7 @@
             'meta' => 'Amet',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=34',
+                'src' => 'https://picsum.photos/id/34/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]

--- a/views/pages/components/usage/block/square.blade.php
+++ b/views/pages/components/usage/block/square.blade.php
@@ -5,7 +5,7 @@
             'meta' => 'Etiam Tristique Magna Nullam',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=10',
+                'src' => 'https://picsum.photos/id/10/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ],
@@ -19,7 +19,7 @@
             'meta' => 'Ultricies',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=11',
+                'src' => 'https://picsum.photos/id/11/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -32,7 +32,7 @@
             'meta' => 'Porta Risus Venenatis',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=12',
+                'src' => 'https://picsum.photos/id/12/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -45,7 +45,7 @@
             'meta' => 'Adipiscing Fusce',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=13',
+                'src' => 'https://picsum.photos/id/13/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -58,7 +58,7 @@
             'meta' => 'Euismod',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/510?image=14',
+                'src' => 'https://picsum.photos/id/14/680/510',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]

--- a/views/pages/components/usage/block/tall.blade.php
+++ b/views/pages/components/usage/block/tall.blade.php
@@ -6,7 +6,7 @@
             'meta' => 'Ultricies',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/1000?image=15',
+                'src' => 'https://picsum.photos/id/15/680/1000',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ],
@@ -21,7 +21,7 @@
             'meta' => 'Malesuada Parturient Dolor',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/1000?image=16',
+                'src' => 'https://picsum.photos/id/16/680/1000',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ],
@@ -37,7 +37,7 @@
             'meta' => 'Porta Ultricies',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/1000?image=17',
+                'src' => 'https://picsum.photos/id/17/680/1000',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ],
@@ -52,7 +52,7 @@
             'meta' => 'Nibh',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/1000?image=18',
+                'src' => 'https://picsum.photos/id/18/680/1000',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]
@@ -66,7 +66,7 @@
             'meta' => 'Ornare Malesuada',
             'filled' => true,
             'image' => [
-                'src' => 'https://picsum.photos/680/1000?image=19',
+                'src' => 'https://picsum.photos/id/19/680/1000',
                 'alt' => 'ALT', 
                 'backgroundColor' => 'secondary',
             ]

--- a/views/pages/components/usage/card.blade.php
+++ b/views/pages/components/usage/card.blade.php
@@ -3,7 +3,7 @@
         'avatar' => [
             'name' => 'Snowflake'
         ],
-        'image' => 'https://picsum.photos/300/200?image=1077',
+        'image' => 'https://picsum.photos/id/1077/300/200',
         'href' => 'http://styleguide.helsingborg.se/card',
         'title' => [
             'text' => 'Maybe you also need to add some cool icon-buttons',

--- a/views/pages/components/usage/comment/comment.blade.php
+++ b/views/pages/components/usage/comment/comment.blade.php
@@ -33,7 +33,7 @@
     'author' => 'Peter Olsson',
     'text' => 'This is a reply comment text',
     'icon' => 'face',
-    'author_image' => 'https://picsum.photos/70/70?image=64',
+    'author_image' => 'https://picsum.photos/id/64/70/70',
     'date' => '2020-01-01 17:25:43',
     'is_reply' => true
 ])

--- a/views/pages/components/usage/gallery.blade.php
+++ b/views/pages/components/usage/gallery.blade.php
@@ -1,12 +1,12 @@
 @gallery(
     [
         'list' => [
-            ['largeImage' => "https://picsum.photos/900/600?image=1026", 'smallImage' => "https://picsum.photos/300/200?image=1026", 'caption' => "Image with stuff", 'alt' => "The alt text"],
-            ['largeImage' => "https://picsum.photos/900/600?image=1038", 'smallImage' => "https://picsum.photos/300/200?image=1038", 'caption' => "Image is an image.", 'alt' => "The alt text"],
-            ['largeImage' => "https://picsum.photos/900/600?image=1043", 'smallImage' => "https://picsum.photos/300/200?image=1043", 'caption' => "Image with stuff", 'alt' => "The alt text"],
-            ['largeImage' => "https://picsum.photos/900/600?image=1039", 'smallImage' => "https://picsum.photos/300/200?image=1039", 'caption' => "Image with stuff", 'alt' => "The alt text"],
-            ['largeImage' => "https://picsum.photos/900/600?image=1006", 'smallImage' => "https://picsum.photos/300/200?image=1006", 'caption' => "Image with stuff", 'alt' => "The alt text"],
-            ['largeImage' => "https://picsum.photos/900/600?image=993", 'smallImage' => "https://picsum.photos/300/200?image=993", 'caption' => "Image is an image.", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/1026/900/600", 'smallImage' => "https://picsum.photos/id/1026/300/200", 'caption' => "Image with stuff", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/1038/900/600", 'smallImage' => "https://picsum.photos/id/1038/300/200", 'caption' => "Image is an image.", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/1043/900/600", 'smallImage' => "https://picsum.photos/id/1043/300/200", 'caption' => "Image with stuff", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/1039/900/600", 'smallImage' => "https://picsum.photos/id/1039/300/200", 'caption' => "Image with stuff", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/1006/900/600", 'smallImage' => "https://picsum.photos/id/1006/300/200", 'caption' => "Image with stuff", 'alt' => "The alt text"],
+            ['largeImage' => "https://picsum.photos/id/993/900/600", 'smallImage' => "https://picsum.photos/id/993/300/200", 'caption' => "Image is an image.", 'alt' => "The alt text"],
         ]
     ]
 )

--- a/views/pages/components/usage/hero/large.blade.php
+++ b/views/pages/components/usage/hero/large.blade.php
@@ -1,5 +1,5 @@
 @hero([
-    "image" => "https://picsum.photos/1500/1000?image=1026",
+    "image" => "https://picsum.photos/id/1026/1500/1000",
     "size" => "large",
     "overlay" => "vibrant",
     "title" => "Donec ullamcorper nulla non metus auctor fringilla.",

--- a/views/pages/components/usage/hero/largenotext.blade.php
+++ b/views/pages/components/usage/hero/largenotext.blade.php
@@ -1,5 +1,5 @@
 @hero([
-    "image" => "https://picsum.photos/1500/1000?image=1027",
+    "image" => "https://picsum.photos/id/1027/1500/1000",
     "size" => "large"
 ])
 @endhero

--- a/views/pages/components/usage/hero/normal.blade.php
+++ b/views/pages/components/usage/hero/normal.blade.php
@@ -1,5 +1,5 @@
 @hero([
-    "image" => "https://picsum.photos/1500/1000?image=1026",
+    "image" => "https://picsum.photos/id/1026/1500/1000",
     "size" => "normal",
     "overlay" => "neutral",
     "title" => "Donec ullamcorper nulla non metus auctor fringilla.",

--- a/views/pages/components/usage/hero/small.blade.php
+++ b/views/pages/components/usage/hero/small.blade.php
@@ -1,5 +1,5 @@
 @hero([
-    "image" => "https://picsum.photos/1500/1000?image=1026",
+    "image" => "https://picsum.photos/id/1026/1500/1000",
     "size" => "small",
     "overlay" => "neutral",
     "title" => "Donec ullamcorper nulla non.",

--- a/views/pages/components/usage/image/modal.blade.php
+++ b/views/pages/components/usage/image/modal.blade.php
@@ -1,5 +1,5 @@
 @image([
-    'src'=> "https://picsum.photos/300/200?image=1028",
+    'src'=> "https://picsum.photos/id/1028/300/200",
     'alt' => "This is a image",
     'caption' => "Click image to open a modal with a bigger image example",
     'openModal' => true

--- a/views/pages/components/usage/image/plain.blade.php
+++ b/views/pages/components/usage/image/plain.blade.php
@@ -1,5 +1,5 @@
 @image([
-    'src'=> "https://picsum.photos/300/200?image=1026",
+    'src'=> "https://picsum.photos/id/1026/300/200",
     'alt' => "This is a image",
     'caption' => "Hey, I am a caption for an image",
 ])

--- a/views/pages/components/usage/image/rounded.blade.php
+++ b/views/pages/components/usage/image/rounded.blade.php
@@ -1,5 +1,5 @@
 @image([
-    'src'=> "https://picsum.photos/300/200?image=1032",
+    'src'=> "https://picsum.photos/id/1032/300/200",
     'alt' => "This is a image",
     'caption' => "Image with rounded corners (default size: md)",
     'rounded' => true

--- a/views/pages/components/usage/segment/full-width-card.blade.php
+++ b/views/pages/components/usage/segment/full-width-card.blade.php
@@ -2,7 +2,7 @@
     'title'             => 'Fusce Amet Parturient Etiam',
     'content'           => 'Curabitur blandit tempus porttitor. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.',
     'layout'            => 'full-width',
-    'image'             => 'https://i.picsum.photos/id/308/1536/1024.jpg?hmac=sENdBVMjJ5k40eSlDyPh8CZKbXjOm1S73hukmgfyMKQ',
+    'image'             => 'https://picsum.photos/id/308/1536/1024',
     'background'        => 'primary',
     'textColor'         => 'light',
     'overlay'           => 'dark'

--- a/views/pages/components/usage/segment/full-width.blade.php
+++ b/views/pages/components/usage/segment/full-width.blade.php
@@ -2,7 +2,7 @@
     'title'             => 'Fusce Amet Parturient Etiam',
     'content'           => 'Curabitur blandit tempus porttitor. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.',
     'layout'            => 'full-width',
-    'image'             => 'https://i.picsum.photos/id/342/2896/1944.jpg?hmac=_2cYDHi2iG1XY53gvXOrhrEWIP5R5OJlP7ySYYCA0QA',
+    'image'             => 'https://picsum.photos/id/342/2896/1944',
     'background'        => 'primary',
     'textColor'         => 'light',
     'overlay'           => 'dark',

--- a/views/pages/components/usage/slider/slider_with_cards.blade.php
+++ b/views/pages/components/usage/slider/slider_with_cards.blade.php
@@ -17,7 +17,7 @@
 
             @card([
                 'link' => 'https://www.helsingborg.se',
-                'image' => ['src' => "https://picsum.photos/id/$i/267", 'alt' => 'ALT'],
+                'image' => ['src' => "https://picsum.photos/seed/$i/267", 'alt' => 'ALT'],
                 'heading' => "Card #$i",
                 'content' => "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 'classList' => ['u-color__text--info', 'c-card--focus-inset'],

--- a/views/pages/components/usage/testimonials.blade.php
+++ b/views/pages/components/usage/testimonials.blade.php
@@ -6,7 +6,7 @@
             'title' => 'Spiritual and political leader of Tibetans',
             'titleElement' => 'h5',
             'testimonial' => "Anger and hatred are signs of weakness, while compassion is a sure sign of strength. Bless this component...",
-            'image' => 'https://picsum.photos/200/200?image=1022',
+            'image' => 'https://picsum.photos/id/1022/200/200?',
             'quoteColor' => 'primary'
         ),
         array(
@@ -14,7 +14,7 @@
             'title' => 'American track athlete, OS gold winner.',
             'titleElement' => 'h5',
             'testimonial' => "For a time, at least, I was the most famous person in the entire world. Great work dudes!",
-            'image' => 'https://picsum.photos/200/200?image=1023',
+            'image' => 'https://picsum.photos/id/1023/200/200',
             'quoteColor' => 'secondary'
         ),
         array(
@@ -22,7 +22,7 @@
             'title' => 'A great musician, member of the Beatles',
             'testimonial' => "Everything will be okay in the end. If it’s not okay, it’s not the end. Love your stuff, Peace!",
             'titleElement' => 'h5',
-            'image' => 'https://picsum.photos/200/200?image=1024',
+            'image' => 'https://picsum.photos/id/1024/200/200',
             'quoteColor' => 'primary'
         ),
     )]

--- a/views/pages/utilities/responsive-media.blade.php
+++ b/views/pages/utilities/responsive-media.blade.php
@@ -7,7 +7,7 @@
         #Responsive Media
     @endmarkdown
     @utility_doc(['viewDoc' => ['type' => 'utility', 'root' => 'responsive-media', 'config' => 'responsive-media']])
-        <img src="https://picsum.photos/300/200?image=1026" class="u-media--responsive"/>
+        <img src="https://picsum.photos/id/1026/300/200" class="u-media--responsive"/>
     @endutility_doc
 
 </article>


### PR DESCRIPTION
Hi there,

I noticed that you were hardcoding some of the signed image URLs for Lorem Picsum (the ones using the `i.picsum.photos` domain) for your placeholders, these URLs are not guaranteed to be stable, and this domain was removed entirely recently, as such I've changed them to use the `picsum.photos` API as intended instead.

I've also removed the use of the `?image=` query parameter as this has been deprecated for several years, and replaced the use of `/id/{}` with `/seed` for the case where you dynamically references images in a loop, as there's no guarantee that all IDs within a given numeric range exists.