### PR TITLE
Remove rounded button inheritance from rounded form

### DIFF
--- a/source/sass/component/_form.scss
+++ b/source/sass/component/_form.scss
@@ -13,7 +13,7 @@
   }
 
   &.c-form--rounded {
-    button.c-button, input {
+    .c-button, input {
       border-radius: calc($base * 3);
     }
   }

--- a/source/sass/component/_form.scss
+++ b/source/sass/component/_form.scss
@@ -11,10 +11,4 @@
   &.is-invalid .c-form__notice-failed {
     display: block;
   }
-
-  &.c-form--rounded {
-    .c-button, input {
-      border-radius: calc($base * 3);
-    }
-  }
 }


### PR DESCRIPTION
The shape of buttons should be controlled by the "shape" attribute on the button component. This removes the override that applies rounded corners to all buttons inside a form with the --rounded modifier.