### PR TITLE
fix: Resolve map component zooming issue when page is reloaded

### DIFF
--- a/source/js/openStreetMap.ts
+++ b/source/js/openStreetMap.ts
@@ -82,7 +82,7 @@ class OpenStreetMap {
                 const marker = layer as Marker;
                 const latLng = marker.getLatLng();
                 if (latLng && latLng.lat.toString() == params.lat && latLng.lng.toString() == params.lng) {
-                    zoomToMarker(marker);
+                    zoomToMarker(marker, this.container);
                 }
             }
         });

--- a/source/js/openstreetmap/addMarkers.ts
+++ b/source/js/openstreetmap/addMarkers.ts
@@ -1,4 +1,4 @@
-import { getMarkerDataFromElement, pushCoordinatesToBrowserHistory } from './helpers/osmHelpers';
+import { getMarkerDataFromElement, pushCoordinatesToBrowserHistory, allLocations } from './helpers/osmHelpers';
 import L, { Map as LeafletMap, Marker, MarkerClusterGroup } from 'leaflet';
 import { MarkerElementObjects, Location, Tooltip, Icon } from './interface/interface';
 
@@ -18,25 +18,10 @@ class AddMarkers {
 
         this.addMarkersToMap();
     }
-    
-    private getAllLocations() {
-        let locations = this.locations ?? [];
-        const sidebar = this.container?.querySelector('.c-openstreetmap__sidebar');
-
-        if (!sidebar) return locations;
-        
-        const placeElements = sidebar.querySelectorAll('[data-js-map-location]');
-        
-        placeElements.forEach(element => {
-            locations.push(getMarkerDataFromElement(element as HTMLElement));
-        });
-        
-        return locations;
-    }
 
     private addMarkersToMap() {
-        const locations = this.getAllLocations() ?? [];
-        locations.forEach((location, index) => {
+        const locations = allLocations(this.container) ?? [];
+        locations.forEach((location: Location) => {
             if (location?.lat && location?.lng) {
                 let customIcon: Icon | undefined = undefined;
                 if (location?.icon) {

--- a/source/js/openstreetmap/helpers/osmHelpers.ts
+++ b/source/js/openstreetmap/helpers/osmHelpers.ts
@@ -1,13 +1,37 @@
 import L, { Layer, Map as LeafletMap, Marker, MarkerClusterGroup } from 'leaflet';
 
-export function zoomToMarker(marker: Marker | undefined) {
+export function zoomToMarker(marker: Marker | undefined, container: HTMLElement | false = false) {
     if (marker && (marker as any).__parent) {
         const cluster = (marker as any).__parent;
-        cluster.zoomToBounds();
+        let hasMoreThanOnePin = true;
+
+        if (container) {
+            hasMoreThanOnePin = allLocations(container).length > 1;
+        }
+
+        if (hasMoreThanOnePin) {
+            cluster.zoomToBounds();
+        } 
+        
         setTimeout(function () {
             marker.openPopup();
         }, 300);
     }
+}
+
+export function allLocations(container: HTMLElement) {
+    let locations = JSON.parse(container.getAttribute('data-js-map-pin-data') || '[]') ?? [];
+    const sidebar = container?.querySelector('.c-openstreetmap__sidebar');
+
+    if (!sidebar) return locations;
+    
+    const placeElements = sidebar.querySelectorAll('[data-js-map-location]');
+    
+    placeElements.forEach(element => {
+        locations.push(getMarkerDataFromElement(element as HTMLElement));
+    });
+    
+    return locations;
 }
 
 export function getElementJSONLocation(el: HTMLElement) {


### PR DESCRIPTION
When only one pin exists and has been clicked. On page reload, map zooms out to max