### PR TITLE
fix: event style with a better overview in mobiles

### DIFF
--- a/source/sass/component/_block.scss
+++ b/source/sass/component/_block.scss
@@ -73,6 +73,9 @@ $c-block-image-background-color: var(--c-block-image-background-color, $color-se
         @include ratio(1, 1, true); 
         &:before {
             width: 0;
+            @include mq('xs') {
+                display: none;
+            }
         }
     }
     
@@ -80,6 +83,9 @@ $c-block-image-background-color: var(--c-block-image-background-color, $color-se
         @include ratio(4, 3, true); 
         &:before {
             width: 0;
+            @include mq('xs') {
+                display: none;
+            }
         }
     }
     
@@ -87,6 +93,9 @@ $c-block-image-background-color: var(--c-block-image-background-color, $color-se
         @include ratio(12, 16, true); 
         &:before {
             width: 0;
+            @include mq('xs') {
+                display: none;
+            }
         }
     }
     
@@ -94,6 +103,9 @@ $c-block-image-background-color: var(--c-block-image-background-color, $color-se
         @include ratio(16, 9, true);
         &:before {
             width: 0;
+            @include mq('xs') {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
In need of fix in components for date badge.
<img width="252" alt="Skärmavbild 2024-04-18 kl  11 48 19" src="https://github.com/helsingborg-stad/styleguide/assets/153924153/60594c1b-117b-420b-8086-fd7ce9b1e24d">
