### PR TITLE
feat: allow brand image to be loaded before calculating width

### DIFF
--- a/source/js/brand.ts
+++ b/source/js/brand.ts
@@ -1,15 +1,10 @@
 class BrandViewBoxManager {
-    private svg: SVGElement;
-    private textElement: HTMLElement;
-    private figureElement: HTMLElement | null;
-    private container: HTMLElement;
-
-    constructor(private brand: HTMLElement) {
-        this.container = this.brand.querySelector<HTMLElement>('.c-brand__container')!;
-        this.svg = this.brand.querySelector<SVGElement>('.c-brand__viewbox')!;
-        this.textElement = this.brand.querySelector<HTMLElement>('.c-brand__text')!;
-        this.figureElement = this.brand.querySelector<HTMLElement>('.c-brand__logotype'); // Optional
-
+    constructor(
+        private svg: SVGElement, 
+        private container: HTMLElement, 
+        private textElement: HTMLElement, 
+        private figureElement: HTMLElement | null
+    ) {
         this.updateViewBox();
     }
 
@@ -35,7 +30,26 @@ class BrandViewBoxManager {
 export function initializeBrand(): void {
     document.querySelectorAll<HTMLElement>('.c-brand').forEach((brandElement) => {
         if (brandElement) {
-            new BrandViewBoxManager(brandElement);
+            const svg = brandElement.querySelector<SVGElement>('.c-brand__viewbox');
+            const container = brandElement.querySelector<HTMLElement>('.c-brand__container');
+            const textElement = brandElement.querySelector<HTMLElement>('.c-brand__text');
+            const figureElement = brandElement.querySelector<HTMLElement>('.c-brand__logotype');
+
+            if (!svg || !container || !textElement) {
+                return;
+            }
+
+            const img = figureElement?.querySelector('img');
+
+            const initViewBoxManager = () => {
+                new BrandViewBoxManager(svg, container, textElement, figureElement);
+            }
+
+            if (!img || img.complete) {
+                initViewBoxManager();
+            } else {
+                img.addEventListener('load', initViewBoxManager);
+            }
         }
     });
 }

--- a/source/js/brand.ts
+++ b/source/js/brand.ts
@@ -29,27 +29,25 @@ class BrandViewBoxManager {
 
 export function initializeBrand(): void {
     document.querySelectorAll<HTMLElement>('.c-brand').forEach((brandElement) => {
-        if (brandElement) {
-            const svg = brandElement.querySelector<SVGElement>('.c-brand__viewbox');
-            const container = brandElement.querySelector<HTMLElement>('.c-brand__container');
-            const textElement = brandElement.querySelector<HTMLElement>('.c-brand__text');
-            const figureElement = brandElement.querySelector<HTMLElement>('.c-brand__logotype');
+        const svg = brandElement.querySelector<SVGElement>('.c-brand__viewbox');
+        const container = brandElement.querySelector<HTMLElement>('.c-brand__container');
+        const textElement = brandElement.querySelector<HTMLElement>('.c-brand__text');
+        const figureElement = brandElement.querySelector<HTMLElement>('.c-brand__logotype');
 
-            if (!svg || !container || !textElement) {
-                return;
-            }
+        if (!svg || !container || !textElement) {
+            return;
+        }
 
-            const img = figureElement?.querySelector('img');
+        const img = figureElement?.querySelector('img');
 
-            const initViewBoxManager = () => {
-                new BrandViewBoxManager(svg, container, textElement, figureElement);
-            }
+        const initViewBoxManager = () => {
+            new BrandViewBoxManager(svg, container, textElement, figureElement);
+        }
 
-            if (!img || img.complete) {
-                initViewBoxManager();
-            } else {
-                img.addEventListener('load', initViewBoxManager);
-            }
+        if (!img || img.complete) {
+            initViewBoxManager();
+        } else {
+            img.addEventListener('load', initViewBoxManager);
         }
     });
 }


### PR DESCRIPTION
This pull request includes changes to the `source/js/brand.ts` file to improve the initialization and management of the `BrandViewBoxManager` class. The most important changes include refactoring the constructor and updating the initialization function.

Refactoring the `BrandViewBoxManager` class:

* [`source/js/brand.ts`](diffhunk://#diff-09e61e56adc9c88f4e2778e353e6c337055662aa92dc92a83d6dd06506e054d8L2-R7): Modified the `BrandViewBoxManager` constructor to accept specific parameters (`svg`, `container`, `textElement`, `figureElement`) instead of extracting them within the constructor.

Updating the initialization function:

* [`source/js/brand.ts`](diffhunk://#diff-09e61e56adc9c88f4e2778e353e6c337055662aa92dc92a83d6dd06506e054d8L38-R52): Updated the `initializeBrand` function to extract the required elements (`svg`, `container`, `textElement`, `figureElement`) before creating an instance of `BrandViewBoxManager`. Added checks to ensure these elements are present and handled the case where the `img` element within `figureElement` might not be loaded yet.