### PR TITLE
fix: prevent content jump by observing height changes and animate the…

### DIFF
--- a/source/js/app.js
+++ b/source/js/app.js
@@ -51,6 +51,7 @@ import {initializeMegaMenus} from './megaMenu';
 import {initializeSizeObserver} from './sizeObserver';
 import {initializeBrand} from './brand';
 import {initializeDismissableNotices} from './dismissableNotices';
+import {PreventContentJumpObserver} from './preventContentJumpObserver';
 
 // Instances
 const DeviceDetectInstance = new DeviceDetect(); 
@@ -83,6 +84,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const DynamicSidebarInstance = new DynamicSidebar();
     const filter = new Filter();
     const MenuInstance = new Menu();
+    //const PreventContentJumpObserver = new PreventContentJumpObserver();
+
+    new PreventContentJumpObserver().observe();
 
     selectComponentObserverInstance.observe();
     ToggleClassesInstance.applyToggle();

--- a/source/js/preventContentJumpObserver.ts
+++ b/source/js/preventContentJumpObserver.ts
@@ -1,0 +1,65 @@
+export class PreventContentJumpObserver {
+
+	private readonly attribute = 'data-js-prevent-content-jump';
+
+	constructor() {
+		const container = document.documentElement || document.body;
+		[...container.querySelectorAll<HTMLElement>(`[${this.attribute}]`)].forEach((element) => {
+			this.observeElement(element);
+		});
+	}
+
+	observe(): void {
+		const container = document.documentElement || document.body;
+		const observerOptions = {
+			childList: true,
+			subtree: true
+		};
+
+		const observer = new MutationObserver((mutations) => {
+			mutations.forEach((mutation) => {
+				if (mutation.type === 'childList') {
+					mutation.addedNodes.forEach((node) => {
+						if (node instanceof HTMLElement && node.hasAttribute(this.attribute)) {
+							this.observeElement(node);
+						}
+					});
+				}
+			});
+		});
+
+		observer.observe(container, observerOptions);
+	}
+
+	private observeElement(element: HTMLElement): void {
+		const resizeObserver = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				const el = entry.target as HTMLElement;
+				const prevHeight = parseFloat(el.dataset.prevHeight ?? '') || el.offsetHeight;
+				const newHeight = el.scrollHeight;
+
+				if (prevHeight !== newHeight) {
+					el.style.transition = 'height 0.3s ease';
+					el.style.overflow = 'hidden';
+					el.style.height = `${prevHeight}px`;
+
+					requestAnimationFrame(() => {
+						el.style.height = `${newHeight}px`;
+						el.dataset.prevHeight = newHeight.toString();
+					});
+
+					const cleanup = () => {
+						el.style.height = '';
+						el.style.overflow = '';
+						el.style.transition = '';
+						el.removeEventListener('transitionend', cleanup);
+					};
+
+					el.addEventListener('transitionend', cleanup);
+				}
+			}
+		});
+
+		resizeObserver.observe(element);
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature to prevent content jumps when elements are dynamically added or resized on the page. The main changes include the addition of a new class `PreventContentJumpObserver` and its integration into the existing JavaScript initialization process.

Key changes:

### New Feature Implementation:
* [`source/js/preventContentJumpObserver.ts`](diffhunk://#diff-f151e1fc2afe2103bf65bb6fe3bf84bc7254414ee6f69b00206b6edbe848d98cR1-R65): Added the `PreventContentJumpObserver` class to monitor and adjust the height of elements with the `data-js-prevent-content-jump` attribute to prevent content jumps.

### Integration into Existing Codebase:
* [`source/js/app.js`](diffhunk://#diff-d48a146c34b8a80829d9e0888bed66eecfb83861bba353b7361497367d1e953aR54): Imported the `PreventContentJumpObserver` class and instantiated it within the `DOMContentLoaded` event listener to ensure it starts observing relevant elements when the document is fully loaded. [[1]](diffhunk://#diff-d48a146c34b8a80829d9e0888bed66eecfb83861bba353b7361497367d1e953aR54) [[2]](diffhunk://#diff-d48a146c34b8a80829d9e0888bed66eecfb83861bba353b7361497367d1e953aR87-R89)…m smoothly.